### PR TITLE
Adding vetur support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "README.md",
     "package.json",
     "src/component",
-    "dist/"
+    "dist/",
+    "vetur/"
   ],
   "homepage": "https://github.com/mubaidr/vue-swimlane#readme",
   "keywords": [
@@ -60,5 +61,9 @@
     "dev": "cd src/docs && npm run dev && cd ../..",
     "lint": "eslint --ext .js,.vue --fix ./src/component"
   },
-  "version": "0.4.3"
+  "version": "0.4.3",
+  "vetur": {
+    "tags": "vetur/tags.json",
+    "attributes": "vetur/attributes.json"
+  }
 }

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -1,0 +1,38 @@
+{
+  "vue-swimlane/words":{
+    "type": "string[]",
+    "description": "Required: Array of tags or words to be used on display."
+  },
+  "vue-swimlane/continous":{
+    "type": "boolean",
+    "description": "[Default: false]: If true, list continues forward, repeating the list."
+  },
+  "vue-swimlane/circular":{
+    "type": "boolean",
+    "description": "[Default: false]: If true, list starts from the top after completion."
+  },
+  "vue-swimlane/pause-on-hover":{
+    "type": "boolean",
+    "description": "[Default: true]: If true, animation will pause on mouse hover."
+  },
+  "vue-swimlane/rows":{
+    "type": "number",
+    "description": "[Default: 1]: Number of rows always visible at a time."
+  },
+  "vue-swimlane/scale":{
+    "type": "number",
+    "description": "[Default: 1]: Font size scaling relative to 16px."
+  },
+  "vue-swimlane/transition-duration":{
+    "type": "number",
+    "description": "[Default: 500]: Animation duration for rows."
+  },
+  "vue-swimlane/transition-delay":{
+    "type": "number",
+    "description": "[Default: 250]: Delays between each animation duration in ms."
+  },
+  "vue-swimlane/transition":{
+    "type": "string",
+    "description": "[Default: ease-out]: css transition name."
+  }
+}

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -1,0 +1,17 @@
+{
+  "vue-swimlane":{
+    "attributes":[
+      "words",
+      "continous",
+      "circular",
+      "pause-on-hover",
+      "rows",
+      "scale",
+      "transition-duration",
+      "transition-delay",
+      "transition"
+    ],
+    "subtags":[],
+    "description": "Display a list of words as an animated text swim lane."
+  }
+}


### PR DESCRIPTION
Vetur can provide autocomplete support for custom components through tag and attributes definition files and by linking to them under a `"vetur"` key in the `package.json`. See [this page](https://github.com/vuejs/vetur/blob/master/docs/framework.md) for more details.